### PR TITLE
Enhancement: Implement and register YAMLFileReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.5.* - TBD
+### Added
+  * `TomPHP\ContainerConfigurator\FileReader\YAMLFileReader` for reading
+     YAML files (requires `symfony/yaml` to be installed)
+
 ## 0.5.0 - 2016-09-13
 ### Added
   * `TomPHP\ContainerConfigurator\Configurator` as the main API

--- a/README.md
+++ b/README.md
@@ -78,8 +78,17 @@ read their config is merged in; overwriting any matching keys.
 
 #### Supported Formats
 
-Currently `.php` and `.json` files are supported. PHP config files **must**
-return a PHP array.
+Currently `.php` and `.json` files are supported out of the box. PHP 
+config files **must** return a PHP array. 
+
+`.yaml` and `.yml` files can be read when the package `symfony/yaml` is 
+available. Run
+
+```
+composer require symfony/yaml
+```
+
+to install it.
 
 ### Application Configuration
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     ],
     "suggest": {
         "league/container": "Small but powerful dependency injection container http://container.thephpleague.com",
-        "pimple/pimple": "A small PHP 5.3 dependency injection container http://pimple.sensiolabs.org"
+        "pimple/pimple": "A small PHP 5.3 dependency injection container http://pimple.sensiolabs.org",
+        "symfony/yaml": "For reading configuration from YAML files"
     },
     "require": {
         "php": "^5.6|^7.0",
@@ -27,7 +28,8 @@
         "league/container": "^2.0.2",
         "phpunit/phpunit": "^5.5.4",
         "pimple/pimple": "^3.0.0",
-        "squizlabs/php_codesniffer": "*"
+        "squizlabs/php_codesniffer": "*",
+        "symfony/yaml": "^3.1.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -18,6 +18,8 @@ final class Configurator
     const FILE_READERS = [
         '.json' => FileReader\JSONFileReader::class,
         '.php'  => FileReader\PHPFileReader::class,
+        '.yaml' => FileReader\YAMLFileReader::class,
+        '.yml'  => FileReader\YAMLFileReader::class,
     ];
 
     const CONTAINER_ADAPTERS = [

--- a/src/Exception/InvalidConfigException.php
+++ b/src/Exception/InvalidConfigException.php
@@ -29,4 +29,15 @@ final class InvalidConfigException extends LogicException implements Exception
     {
         return self::create('Invalid JSON in "%s": %s', [$filename, $message]);
     }
+
+    /**
+     * @param string $filename
+     * @param string $message
+     *
+     * @return self
+     */
+    public static function fromYAMLFileError($filename, $message)
+    {
+        return self::create('Invalid YAML in "%s": %s', [$filename, $message]);
+    }
 }

--- a/src/Exception/MissingDependencyException.php
+++ b/src/Exception/MissingDependencyException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TomPHP\ContainerConfigurator\Exception;
+
+use LogicException;
+use TomPHP\ExceptionConstructorTools;
+
+final class MissingDependencyException extends LogicException implements Exception
+{
+    use ExceptionConstructorTools;
+
+    /**
+     * @param string $packageName
+     *
+     * @return self
+     */
+    public static function fromPackageName($packageName)
+    {
+        return self::create('The package "%s" is missing. Please run "composer require %s" to install it.', [
+            $packageName,
+            $packageName,
+        ]);
+    }
+}

--- a/src/FileReader/YAMLFileReader.php
+++ b/src/FileReader/YAMLFileReader.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace TomPHP\ContainerConfigurator\FileReader;
+
+use Assert\Assertion;
+use Symfony\Component\Yaml;
+use TomPHP\ContainerConfigurator\Exception\InvalidConfigException;
+use TomPHP\ContainerConfigurator\Exception\MissingDependencyException;
+
+final class YAMLFileReader implements FileReader
+{
+    /**
+     * @throws MissingDependencyException
+     */
+    public function __construct()
+    {
+        if (!class_exists(Yaml\Yaml::class)) {
+            throw MissingDependencyException::fromPackageName('symfony/yaml');
+        }
+    }
+
+    public function read($filename)
+    {
+        Assertion::file($filename);
+
+        try {
+            $config = Yaml\Yaml::parse(file_get_contents($filename));
+        } catch (Yaml\Exception\ParseException $exception) {
+            throw InvalidConfigException::fromYAMLFileError($filename, $exception->getMessage());
+        }
+
+        return $config;
+    }
+}

--- a/tests/unit/Exception/InvalidConfigExceptionTest.php
+++ b/tests/unit/Exception/InvalidConfigExceptionTest.php
@@ -34,4 +34,12 @@ final class InvalidConfigExceptionTest extends PHPUnit_Framework_TestCase
             InvalidConfigException::fromJSONFileError('example.json', 'JSON Error Message')->getMessage()
         );
     }
+
+    public function testItCanBeCreatedFromYAMLFileError()
+    {
+        $this->assertSame(
+            'Invalid YAML in "example.yml": YAML Error Message',
+            InvalidConfigException::fromYAMLFileError('example.yml', 'YAML Error Message')->getMessage()
+        );
+    }
 }

--- a/tests/unit/Exception/MissingDependencyExceptionTest.php
+++ b/tests/unit/Exception/MissingDependencyExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace tests\unit\TomPHP\ContainerConfigurator\Exception;
+
+use LogicException;
+use PHPUnit_Framework_TestCase;
+use TomPHP\ContainerConfigurator\Exception\Exception;
+use TomPHP\ContainerConfigurator\Exception\MissingDependencyException;
+
+final class MissingDependencyExceptionTest extends PHPUnit_Framework_TestCase
+{
+    public function testItImplementsTheBaseExceptionType()
+    {
+        $this->assertInstanceOf(Exception::class, new MissingDependencyException());
+    }
+
+    public function testItIsALogicException()
+    {
+        $this->assertInstanceOf(LogicException::class, new MissingDependencyException());
+    }
+
+    public function testItCanBeCreatedFromPackageName()
+    {
+        $this->assertSame(
+            'The package "foo/bar" is missing. Please run "composer require foo/bar" to install it.',
+            MissingDependencyException::fromPackageName('foo/bar')->getMessage()
+        );
+    }
+}

--- a/tests/unit/FileReader/ReaderFactoryTest.php
+++ b/tests/unit/FileReader/ReaderFactoryTest.php
@@ -9,6 +9,7 @@ use TomPHP\ContainerConfigurator\Exception\UnknownFileTypeException;
 use TomPHP\ContainerConfigurator\FileReader\JSONFileReader;
 use TomPHP\ContainerConfigurator\FileReader\PHPFileReader;
 use TomPHP\ContainerConfigurator\FileReader\ReaderFactory;
+use TomPHP\ContainerConfigurator\FileReader\YAMLFileReader;
 
 final class ReaderFactoryTest extends PHPUnit_Framework_TestCase
 {
@@ -24,25 +25,46 @@ final class ReaderFactoryTest extends PHPUnit_Framework_TestCase
         $this->factory = new ReaderFactory([
             '.php'  => PHPFileReader::class,
             '.json' => JSONFileReader::class,
+            '.yaml' => YAMLFileReader::class,
+            '.yml' => YAMLFileReader::class,
         ]);
     }
 
-    public function testCreatesAReader()
+    /**
+     * @dataProvider providerCreatesAppropriateFileReader
+     *
+     * @param string $extension
+     * @param string $fileReaderClass
+     */
+    public function testCreatesAppropriateFileReader($extension, $fileReaderClass)
     {
-        $this->createTestFile('test.php');
+        $filename = 'test' . $extension;
 
-        $reader = $this->factory->create($this->getTestPath('test.php'));
+        $this->createTestFile($filename);
 
-        $this->assertInstanceOf(PHPFileReader::class, $reader);
+        $reader = $this->factory->create($this->getTestPath($filename));
+
+        $this->assertInstanceOf($fileReaderClass, $reader);
     }
 
-    public function testCreatesAnotherReader()
+    /**
+     * @return \Generator
+     */
+    public function providerCreatesAppropriateFileReader()
     {
-        $this->createTestFile('test.json');
+        $extensions = [
+            '.json' => JSONFileReader::class,
+            '.php' => PHPFileReader::class,
+            '.yaml' => YAMLFileReader::class,
+            '.yml' => YAMLFileReader::class,
+        ];
 
-        $reader = $this->factory->create($this->getTestPath('test.json'));
-
-        $this->assertInstanceOf(JSONFileReader::class, $reader);
+        foreach ($extensions as $extension => $fileReaderClass) {
+            yield [
+                $extension,
+                $fileReaderClass,
+            ];
+        }
     }
 
     public function testReturnsTheSameReaderForTheSameFileType()

--- a/tests/unit/FileReader/YAMLFileReaderTest.php
+++ b/tests/unit/FileReader/YAMLFileReaderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace tests\unit\TomPHP\ContainerConfigurator\FileReader;
+
+use InvalidArgumentException;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Yaml;
+use tests\support\TestFileCreator;
+use TomPHP\ContainerConfigurator\Exception\InvalidConfigException;
+use TomPHP\ContainerConfigurator\FileReader\FileReader;
+use TomPHP\ContainerConfigurator\FileReader\YAMLFileReader;
+
+final class YAMLFileReaderTest extends PHPUnit_Framework_TestCase
+{
+    use TestFileCreator;
+
+    /**
+     * @var YAMLFileReader
+     */
+    private $reader;
+
+    protected function setUp()
+    {
+        $this->reader = new YAMLFileReader();
+    }
+
+    public function testItIsAFileReader()
+    {
+        $this->assertInstanceOf(FileReader::class, $this->reader);
+    }
+
+    public function testItThrowsIfFileDoesNotExist()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->reader->read('file-which-does-not-exist');
+    }
+
+    public function testReadsAYAMLConfigFile()
+    {
+        $config = ['key' => 'value', 'sub' => ['key' => 'value']];
+
+        $this->createTestFile('config.yml', Yaml\Yaml::dump($config));
+
+        $this->assertEquals($config, $this->reader->read($this->getTestPath('config.yml')));
+    }
+
+    public function testItThrowsIfTheConfigIsInvalid()
+    {
+        $this->expectException(InvalidConfigException::class);
+
+        $this->createTestFile('config.yml', '[not yaml;');
+
+        $this->reader->read($this->getTestPath('config.yml'));
+    }
+}


### PR DESCRIPTION
This PR

* [x] requires `symfony/yaml` as a development dependency and suggests using it
* [x] uses `Symfony\Component\Yaml\Yaml` to parse YAML files