### PR TITLE
Fix: Sort fixers

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -5,13 +5,13 @@ $finder = Symfony\CS\Finder\DefaultFinder::create()->in(__DIR__);
 return Symfony\CS\Config\Config::create()
     ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
     ->fixers([
-        'unused_use',
-        'new_with_braces',
-        'phpdoc_scalar',
-        'phpdoc_params',
         'multiline_array_trailing_comma',
+        'new_with_braces',
+        'phpdoc_params',
+        'phpdoc_scalar',
         'phpdoc_trim',
         'return',
+        'unused_use',
     ])
     ->setUsingCache(true)
     ->setUsingLinter(true)


### PR DESCRIPTION
This PR

* [x] sorts fixers in `.php_cs`

💁 This makes it easier to add new fixers, as it is easier to find items in a list when it is sorted. For this, of course, I used https://plugins.jetbrains.com/plugin/5919?pr=clion.