### PR TITLE
Fix: Reduce visibility of setUp()

### DIFF
--- a/tests/unit/FileReader/ReaderFactoryTest.php
+++ b/tests/unit/FileReader/ReaderFactoryTest.php
@@ -19,7 +19,7 @@ final class ReaderFactoryTest extends PHPUnit_Framework_TestCase
      */
     private $factory;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->factory = new ReaderFactory([
             '.php'  => PHPFileReader::class,


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `setUp()` from `public` to `protected`