### PR TITLE
Enhancement: Enable ordered_use fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -7,6 +7,7 @@ return Symfony\CS\Config\Config::create()
     ->fixers([
         'multiline_array_trailing_comma',
         'new_with_braces',
+        'ordered_use',
         'phpdoc_params',
         'phpdoc_scalar',
         'phpdoc_trim',

--- a/tests/unit/ApplicationConfigTest.php
+++ b/tests/unit/ApplicationConfigTest.php
@@ -4,8 +4,8 @@ namespace tests\unit\TomPHP\ContainerConfigurator;
 
 use InvalidArgumentException;
 use PHPUnit_Framework_TestCase;
-use TomPHP\ContainerConfigurator\ApplicationConfig;
 use tests\support\TestFileCreator;
+use TomPHP\ContainerConfigurator\ApplicationConfig;
 use TomPHP\ContainerConfigurator\Exception\ReadOnlyException;
 
 final class ApplicationConfigTest extends PHPUnit_Framework_TestCase

--- a/tests/unit/ContainerAdapterFactoryTest.php
+++ b/tests/unit/ContainerAdapterFactoryTest.php
@@ -3,11 +3,11 @@
 namespace tests\unit\TomPHP\ContainerConfigurator;
 
 use PHPUnit_Framework_TestCase;
-use TomPHP\ContainerConfigurator\ContainerAdapterFactory;
-use TomPHP\ContainerConfigurator\Exception\UnknownContainerException;
 use tests\mocks\ExampleContainer;
 use tests\mocks\ExampleContainerAdapter;
 use tests\mocks\ExampleExtendedContainer;
+use TomPHP\ContainerConfigurator\ContainerAdapterFactory;
+use TomPHP\ContainerConfigurator\Exception\UnknownContainerException;
 
 final class ContainerAdapterFactoryTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/unit/FileReader/JSONFileReaderTest.php
+++ b/tests/unit/FileReader/JSONFileReaderTest.php
@@ -4,10 +4,10 @@ namespace tests\unit\TomPHP\ContainerConfigurator\FileReader;
 
 use InvalidArgumentException;
 use PHPUnit_Framework_TestCase;
+use tests\support\TestFileCreator;
 use TomPHP\ContainerConfigurator\Exception\InvalidConfigException;
 use TomPHP\ContainerConfigurator\FileReader\FileReader;
 use TomPHP\ContainerConfigurator\FileReader\JSONFileReader;
-use tests\support\TestFileCreator;
 
 final class JSONFileReaderTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/unit/FileReader/PHPFileReaderTest.php
+++ b/tests/unit/FileReader/PHPFileReaderTest.php
@@ -4,10 +4,10 @@ namespace tests\unit\TomPHP\ContainerConfigurator\FileReader;
 
 use InvalidArgumentException;
 use PHPUnit_Framework_TestCase;
+use tests\support\TestFileCreator;
 use TomPHP\ContainerConfigurator\Exception\InvalidConfigException;
 use TomPHP\ContainerConfigurator\FileReader\FileReader;
 use TomPHP\ContainerConfigurator\FileReader\PHPFileReader;
-use tests\support\TestFileCreator;
 
 final class PHPFileReaderTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/unit/FileReader/ReaderFactoryTest.php
+++ b/tests/unit/FileReader/ReaderFactoryTest.php
@@ -4,11 +4,11 @@ namespace tests\unit\TomPHP\ContainerConfigurator\FileReader;
 
 use InvalidArgumentException;
 use PHPUnit_Framework_TestCase;
+use tests\support\TestFileCreator;
 use TomPHP\ContainerConfigurator\Exception\UnknownFileTypeException;
 use TomPHP\ContainerConfigurator\FileReader\JSONFileReader;
 use TomPHP\ContainerConfigurator\FileReader\PHPFileReader;
 use TomPHP\ContainerConfigurator\FileReader\ReaderFactory;
-use tests\support\TestFileCreator;
 
 final class ReaderFactoryTest extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
This PR

* [x] enables the `ordered_use` fixer
* [x] runs `composer cs:fix`

💁 For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/1.12#usage:

> **ordered_use [contrib]**
> Ordering use statements.