### PR TITLE
Allow non-string arguments to be used with Pimple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased - TBD
+### Fixed
+  * Non-string arguments can be provided to Pimple services.
+
 ## 0.5.1 - 2016-09-18
 ### Added
   * `TomPHP\ContainerConfigurator\FileReader\YAMLFileReader` for reading

--- a/src/Pimple/PimpleContainerAdapter.php
+++ b/src/Pimple/PimpleContainerAdapter.php
@@ -120,6 +120,10 @@ final class PimpleContainerAdapter implements ContainerAdapter
     {
         return array_map(
             function ($argument) {
+                if (!is_string($argument)) {
+                    return $argument;
+                }
+
                 if (isset($this->container[$argument])) {
                     return $this->container[$argument];
                 }

--- a/tests/acceptance/SupportsServiceConfig.php
+++ b/tests/acceptance/SupportsServiceConfig.php
@@ -216,6 +216,31 @@ trait SupportsServiceConfig
         assertEquals([ExampleClass::class, 'arg2'], $instance->getConstructorArgs());
     }
 
+    public function testItUsesComplexConstructorArguments()
+    {
+        $config = [
+            'di' => [
+                'services' => [
+                    'example_class' => [
+                        'class' => ExampleClassWithArgs::class,
+                        'arguments' => [
+                            ['example_array'],
+                            new \stdClass(),
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        Configurator::apply()
+            ->configFromArray($config)
+            ->to($this->container);
+
+        $instance = $this->container->get('example_class');
+
+        assertEquals([['example_array'], new \stdClass()], $instance->getConstructorArgs());
+    }
+
     public function testItCallsSetterMethods()
     {
         $config = [


### PR DESCRIPTION
There was a bug which would cause Pimple to fail to create
a service if it's argument was an array or object.