### PR TITLE
Feature: Service Aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,21 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased - TBD
+### Added
+  * Service aliases.
+
 ### Fixed
   * Non-string arguments can be provided to Pimple services.
 
 ## 0.5.1 - 2016-09-18
 ### Added
   * `TomPHP\ContainerConfigurator\FileReader\YAMLFileReader` for reading
-     YAML files (requires `symfony/yaml` to be installed)
-  * Service factories
+     YAML files (requires `symfony/yaml` to be installed).
+  * Service factories.
 
 ## 0.5.0 - 2016-09-13
 ### Added
-  * `TomPHP\ContainerConfigurator\Configurator` as the main API
+  * `TomPHP\ContainerConfigurator\Configurator` as the main API.
   * If `class` is left out of the config for a service, then the service name
     is assumed to be the name of the class.
   * Services can be set as singleton by default.

--- a/README.md
+++ b/README.md
@@ -169,9 +169,7 @@ $config = [
                     'setLogLevel' => [ 'info' ],
                 ],
             ],
-            StdoutLogger::class => [
-                'class' => StdoutLogger::class,
-            ],
+            StdoutLogger::class => [],
         ],
     ],
 ];
@@ -180,6 +178,32 @@ $container = new Container();
 Configurator::apply()->configFromArray($config)->to($container);
 
 $logger = $container->get('logger'));
+```
+
+#### Service Aliases
+
+You can create an alias to another service by using the `service` keyword
+instead of `class`:
+
+```php
+$config = [
+    'database' => [ /* ... */ ],
+    'di' => [
+        'services' => [
+            DatabaseConnection::class => [
+                'service' => MySQLDatabaseConnection::class,
+            ],
+            MySQLDatabaseConnection::class => [
+                'arguments' => [
+                    'config.database.host',
+                    'config.database.username',
+                    'config.database.password',
+                    'config.database.dbname',
+                ],
+            ],
+        ],
+    ],
+];
 ```
 
 #### Service Factories

--- a/src/Exception/InvalidConfigException.php
+++ b/src/Exception/InvalidConfigException.php
@@ -53,4 +53,30 @@ final class InvalidConfigException extends LogicException implements Exception
             [$name]
         );
     }
+
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public static function fromNameWhenClassAndServiceSpecified($name)
+    {
+        return self::create(
+            'Both "class" and "service" are specified for service "%s"; these cannot be used together.',
+            [$name]
+        );
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public static function fromNameWhenFactoryAndServiceSpecified($name)
+    {
+        return self::create(
+            'Both "factory" and "service" are specified for service "%s"; these cannot be used together.',
+            [$name]
+        );
+    }
 }

--- a/src/League/ServiceServiceProvider.php
+++ b/src/League/ServiceServiceProvider.php
@@ -52,6 +52,15 @@ final class ServiceServiceProvider extends AbstractServiceProvider
             return;
         }
 
+        if ($definition->isAlias()) {
+            $this->getContainer()->add(
+                $definition->getName(),
+                $this->createAliasFactory($definition)
+            );
+
+            return;
+        }
+
         $service = $this->getContainer()->add(
             $definition->getName(),
             $definition->getClass(),
@@ -75,6 +84,18 @@ final class ServiceServiceProvider extends AbstractServiceProvider
         foreach ($definition->getMethods() as $method => $args) {
             $service->withMethodCall($method, $args);
         }
+    }
+
+    /**
+     * @param ServiceDefinition $definition
+     *
+     * @return \Closure
+     */
+    private function createAliasFactory(ServiceDefinition $definition)
+    {
+        return function () use ($definition) {
+            return $this->getContainer()->get($definition->getClass());
+        };
     }
 
     /**

--- a/src/Pimple/PimpleContainerAdapter.php
+++ b/src/Pimple/PimpleContainerAdapter.php
@@ -72,9 +72,15 @@ final class PimpleContainerAdapter implements ContainerAdapter
      */
     private function createFactory(ServiceDefinition $definition)
     {
-        return $definition->isFactory()
-            ? $this->createFactoryFactory($definition)
-            : $this->createInstanceFactory($definition);
+        if ($definition->isFactory()) {
+            return $this->createFactoryFactory($definition);
+        }
+
+        if ($definition->isAlias()) {
+            return $this->createAliasFactory($definition);
+        }
+
+        return $this->createInstanceFactory($definition);
     }
 
     /**
@@ -89,6 +95,18 @@ final class PimpleContainerAdapter implements ContainerAdapter
             $factory = new $className();
 
             return $factory(...$this->resolveArguments($definition->getArguments()));
+        };
+    }
+
+    /**
+     * @param ServiceDefinition $definition
+     *
+     * @return \Closure
+     */
+    private function createAliasFactory(ServiceDefinition $definition)
+    {
+        return function () use ($definition) {
+            return $this->container[$definition->getClass()];
         };
     }
 

--- a/src/ServiceDefinition.php
+++ b/src/ServiceDefinition.php
@@ -29,6 +29,11 @@ final class ServiceDefinition
     private $isFactory;
 
     /**
+     * @var bool
+     */
+    private $isAlias;
+
+    /**
      * @var array
      */
     private $arguments;
@@ -55,6 +60,7 @@ final class ServiceDefinition
         $this->class       = $this->className($name, $config);
         $this->isSingleton = isset($config['singleton']) ? $config['singleton'] : $singletonDefault;
         $this->isFactory   = isset($config['factory']);
+        $this->isAlias     = isset($config['service']);
         $this->arguments   = isset($config['arguments']) ? $config['arguments'] : [];
         $this->methods     = isset($config['methods']) ? $config['methods'] : [];
     }
@@ -92,6 +98,14 @@ final class ServiceDefinition
     }
 
     /**
+     * @return bool
+     */
+    public function isAlias()
+    {
+        return $this->isAlias;
+    }
+
+    /**
      * @return array
      */
     public function getArguments()
@@ -119,6 +133,18 @@ final class ServiceDefinition
     {
         if (isset($config['class']) && isset($config['factory'])) {
             throw InvalidConfigException::fromNameWhenClassAndFactorySpecified($name);
+        }
+
+        if (isset($config['class']) && isset($config['service'])) {
+            throw InvalidConfigException::fromNameWhenClassAndServiceSpecified($name);
+        }
+
+        if (isset($config['factory']) && isset($config['service'])) {
+            throw InvalidConfigException::fromNameWhenFactoryAndServiceSpecified($name);
+        }
+
+        if (isset($config['service'])) {
+            return $config['service'];
         }
 
         if (isset($config['class'])) {

--- a/tests/acceptance/SupportsServiceConfig.php
+++ b/tests/acceptance/SupportsServiceConfig.php
@@ -340,4 +340,27 @@ trait SupportsServiceConfig
         assertInstanceOf(ExampleClassWithArgs::class, $instance);
         assertSame(['example_argument'], $instance->getConstructorArgs());
     }
+
+    public function testItCanCreateAServiceAlias()
+    {
+        $config = [
+            'di' => [
+                'services' => [
+                    'example_class' => [
+                        'class'     => ExampleClass::class,
+                        'singleton' => true,
+                    ],
+                    'example_alias' => [
+                        'service' => 'example_class',
+                    ],
+                ],
+            ],
+        ];
+
+        Configurator::apply()
+            ->configFromArray($config)
+            ->to($this->container);
+
+        assertSame($this->container->get('example_class'), $this->container->get('example_alias'));
+    }
 }

--- a/tests/unit/Exception/InvalidConfigExceptionTest.php
+++ b/tests/unit/Exception/InvalidConfigExceptionTest.php
@@ -50,4 +50,20 @@ final class InvalidConfigExceptionTest extends PHPUnit_Framework_TestCase
             InvalidConfigException::fromNameWhenClassAndFactorySpecified('example')->getMessage()
         );
     }
+
+    public function testItCanBeCreatedFromNameWhenClassAndServiceAreSpecified()
+    {
+        assertSame(
+            'Both "class" and "service" are specified for service "example"; these cannot be used together.',
+            InvalidConfigException::fromNameWhenClassAndServiceSpecified('example')->getMessage()
+        );
+    }
+
+    public function testItCanBeCreatedFromNameWhenFactoryAndServiceAreSpecified()
+    {
+        assertSame(
+            'Both "factory" and "service" are specified for service "example"; these cannot be used together.',
+            InvalidConfigException::fromNameWhenFactoryAndServiceSpecified('example')->getMessage()
+        );
+    }
 }

--- a/tests/unit/ServiceDefinitionTest.php
+++ b/tests/unit/ServiceDefinitionTest.php
@@ -67,6 +67,16 @@ final class ServiceDefinitionTest extends PHPUnit_Framework_TestCase
         $definition = new ServiceDefinition('service_name', ['factory' => __CLASS__]);
 
         assertTrue($definition->isFactory());
+        assertFalse($definition->isAlias());
+        assertSame(__CLASS__, $definition->getClass());
+    }
+
+    public function testServiceAliasDefinition()
+    {
+        $definition = new ServiceDefinition('service_name', ['service' => __CLASS__]);
+
+        assertTrue($definition->isAlias());
+        assertFalse($definition->isFactory());
         assertSame(__CLASS__, $definition->getClass());
     }
 
@@ -75,5 +85,19 @@ final class ServiceDefinitionTest extends PHPUnit_Framework_TestCase
         $this->expectException(InvalidConfigException::class);
 
         new ServiceDefinition('service_name', ['class' => __CLASS__, 'factory' => __CLASS__]);
+    }
+
+    public function testItThrowIfClassAndServiceAreDefined()
+    {
+        $this->expectException(InvalidConfigException::class);
+
+        new ServiceDefinition('service_name', ['class' => __CLASS__, 'service' => __CLASS__]);
+    }
+
+    public function testItThrowIfFactoryAndServiceAreDefined()
+    {
+        $this->expectException(InvalidConfigException::class);
+
+        new ServiceDefinition('service_name', ['factory' => __CLASS__, 'service' => __CLASS__]);
     }
 }


### PR DESCRIPTION
Allow creating an aliased to another service by name.

At this point, I think it would be better to have separate `ClassServiceDefinition`, `AliasServiceDefinition` and `FactoryServiceDefinition` classes. However, this PR does not do this - it just adds the functionality as I need it now.