### PR TITLE
Fix: Pull field into AbstractContainerAdapterTest

### DIFF
--- a/tests/acceptance/AbstractContainerAdapterTest.php
+++ b/tests/acceptance/AbstractContainerAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace tests\acceptance;
 
+use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_TestCase;
 use tests\support\TestFileCreator;
 use TomPHP\ContainerConfigurator\Configurator;
@@ -11,6 +12,11 @@ abstract class AbstractContainerAdapterTest extends PHPUnit_Framework_TestCase
     use SupportsApplicationConfig;
     use SupportsServiceConfig;
     use TestFileCreator;
+
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
 
     public function testItCanBeConfiguredFromAFile()
     {

--- a/tests/acceptance/LeagueContainerAdapterTest.php
+++ b/tests/acceptance/LeagueContainerAdapterTest.php
@@ -8,11 +8,6 @@ final class LeagueContainerAdapterTest extends AbstractContainerAdapterTest
 {
     use SupportsInflectorConfig;
 
-    /**
-     * @var Container
-     */
-    protected $container;
-
     protected function setUp()
     {
         $this->container = new Container();

--- a/tests/acceptance/PimpleContainerAdapterTest.php
+++ b/tests/acceptance/PimpleContainerAdapterTest.php
@@ -2,16 +2,9 @@
 
 namespace tests\acceptance;
 
-use Pimple\Container;
-
 final class PimpleContainerAdapterTest extends AbstractContainerAdapterTest
 {
     use DoesNotSupportInflectors;
-
-    /**
-     * @var Container
-     */
-    protected $container;
 
     protected function setUp()
     {


### PR DESCRIPTION
This PR

* [x] pulls the `$container` field up into the `AbstractContainerAdapterTest`

💁 This makes the most sense as otherwise we hear complains in `AbstractContainerAdapterTest` that the field `$container` is undefined.