### PR TITLE
Fix: Update return type in docblock

### DIFF
--- a/src/ContainerAdapterFactory.php
+++ b/src/ContainerAdapterFactory.php
@@ -21,7 +21,7 @@ final class ContainerAdapterFactory
      *
      * @throws UnknownContainerException
      *
-     * @return void
+     * @return ContainerAdapter
      */
     public function create($container)
     {


### PR DESCRIPTION
This PR

* [x] updates a `@return` type in a docblock

💁 The factory actually returns an implementation of `ContainerAdapter`!