### PR TITLE
Fix: Throw NotContainerAdapterException if adapter is not a ContainerAdapter

### DIFF
--- a/src/ContainerAdapterFactory.php
+++ b/src/ContainerAdapterFactory.php
@@ -2,6 +2,7 @@
 
 namespace TomPHP\ContainerConfigurator;
 
+use TomPHP\ContainerConfigurator\Exception\NotContainerAdapterException;
 use TomPHP\ContainerConfigurator\Exception\UnknownContainerException;
 
 final class ContainerAdapterFactory
@@ -20,6 +21,7 @@ final class ContainerAdapterFactory
      * @param object $container
      *
      * @throws UnknownContainerException
+     * @throws NotContainerAdapterException
      *
      * @return void
      */
@@ -42,6 +44,11 @@ final class ContainerAdapterFactory
         }
 
         $instance = new $class();
+
+        if (!$instance instanceof ContainerAdapter) {
+            throw NotContainerAdapterException::fromClassName($class);
+        }
+
         $instance->setContainer($container);
 
         return $instance;

--- a/src/Exception/NotContainerAdapterException.php
+++ b/src/Exception/NotContainerAdapterException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TomPHP\ContainerConfigurator\Exception;
+
+use LogicException;
+use TomPHP\ExceptionConstructorTools;
+
+final class NotContainerAdapterException extends LogicException implements Exception
+{
+    use ExceptionConstructorTools;
+
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public static function fromClassName($name)
+    {
+        return self::create(
+            'Class "%s" is not a container adapter.',
+            [$name]
+        );
+    }
+}

--- a/tests/mocks/NotContainerAdapter.php
+++ b/tests/mocks/NotContainerAdapter.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace tests\mocks;
+
+final class NotContainerAdapter
+{
+}

--- a/tests/unit/ContainerAdapterFactoryTest.php
+++ b/tests/unit/ContainerAdapterFactoryTest.php
@@ -6,7 +6,9 @@ use PHPUnit_Framework_TestCase;
 use tests\mocks\ExampleContainer;
 use tests\mocks\ExampleContainerAdapter;
 use tests\mocks\ExampleExtendedContainer;
+use tests\mocks\NotContainerAdapter;
 use TomPHP\ContainerConfigurator\ContainerAdapterFactory;
+use TomPHP\ContainerConfigurator\Exception\NotContainerAdapterException;
 use TomPHP\ContainerConfigurator\Exception\UnknownContainerException;
 
 final class ContainerAdapterFactoryTest extends PHPUnit_Framework_TestCase
@@ -44,6 +46,17 @@ final class ContainerAdapterFactoryTest extends PHPUnit_Framework_TestCase
         $this->expectException(UnknownContainerException::class);
 
         $this->subject->create(new \stdClass());
+    }
+
+    public function testItThrowsIfNotAContainerAdapter()
+    {
+        $this->subject = new ContainerAdapterFactory([
+            ExampleContainer::class => NotContainerAdapter::class,
+        ]);
+
+        $this->expectException(NotContainerAdapterException::class);
+
+        $this->subject->create(new ExampleContainer());
     }
 
     public function testItSetsTheContainerOnTheConfigurator()

--- a/tests/unit/Exception/NotContainerAdapterExceptionTest.php
+++ b/tests/unit/Exception/NotContainerAdapterExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace tests\unit\TomPHP\ContainerConfigurator\Exception;
+
+use LogicException;
+use PHPUnit_Framework_TestCase;
+use TomPHP\ContainerConfigurator\Exception\Exception;
+use TomPHP\ContainerConfigurator\Exception\NotContainerAdapterException;
+
+final class NotContainerAdapterExceptionTest extends PHPUnit_Framework_TestCase
+{
+    public function testItImplementsTheBaseExceptionType()
+    {
+        assertInstanceOf(Exception::class, new NotContainerAdapterException());
+    }
+
+    public function testItIsALogicException()
+    {
+        assertInstanceOf(LogicException::class, new NotContainerAdapterException());
+    }
+
+    public function testItCanBeCreatedFromThePatterns()
+    {
+        assertSame(
+            'Class "Foo" is not a container adapter.',
+            NotContainerAdapterException::fromClassName('Foo')->getMessage()
+        );
+    }
+}


### PR DESCRIPTION
This PR

* [x] throws a `NotContainerAdapterException` if the instance created by the `ContainerAdapterFactory` does not implement `ContainerAdapter`
