### PR TITLE
Fix: Use instanceof instead of is_a()

### DIFF
--- a/src/ContainerAdapterFactory.php
+++ b/src/ContainerAdapterFactory.php
@@ -28,7 +28,7 @@ final class ContainerAdapterFactory
         $class = '';
 
         foreach ($this->config as $containerClass => $configuratorClass) {
-            if (is_a($container, $containerClass)) {
+            if ($container instanceof $containerClass) {
                 $class = $configuratorClass;
                 break;
             }


### PR DESCRIPTION
This PR

* [x] uses `instanceof` instead of `is_a()`