### PR TITLE
Fix: Add missing annotations to docblocks

### DIFF
--- a/src/ApplicationConfig.php
+++ b/src/ApplicationConfig.php
@@ -3,6 +3,7 @@
 namespace TomPHP\ContainerConfigurator;
 
 use ArrayAccess;
+use InvalidArgumentException;
 use IteratorAggregate;
 use TomPHP\ContainerConfigurator\Exception\EntryDoesNotExistException;
 use TomPHP\ContainerConfigurator\Exception\ReadOnlyException;
@@ -22,6 +23,8 @@ final class ApplicationConfig implements ArrayAccess, IteratorAggregate
     /**
      * @param array  $config
      * @param string $separator
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct(array $config, $separator = '.')
     {
@@ -38,6 +41,8 @@ final class ApplicationConfig implements ArrayAccess, IteratorAggregate
 
     /**
      * @param string $separator
+     *
+     * @throws InvalidArgumentException
      *
      * @return void
      */
@@ -73,7 +78,11 @@ final class ApplicationConfig implements ArrayAccess, IteratorAggregate
     }
 
     /**
+     * @param mixed $offset
+     *
      * @throws EntryDoesNotExistException
+     *
+     * @return mixed
      */
     public function offsetGet($offset)
     {
@@ -81,6 +90,9 @@ final class ApplicationConfig implements ArrayAccess, IteratorAggregate
     }
 
     /**
+     * @param mixed $offset
+     * @param mixed $value
+     *
      * @throws ReadOnlyException
      */
     public function offsetSet($offset, $value)
@@ -89,6 +101,8 @@ final class ApplicationConfig implements ArrayAccess, IteratorAggregate
     }
 
     /**
+     * @param mixed $offset
+     *
      * @throws ReadOnlyException
      */
     public function offsetUnset($offset)
@@ -112,12 +126,19 @@ final class ApplicationConfig implements ArrayAccess, IteratorAggregate
         return $this->separator;
     }
 
+    /**
+     * @param string $offset
+     *
+     * @return array
+     */
     private function getPath($offset)
     {
         return explode($this->separator, $offset);
     }
 
     /**
+     * @param array $path
+     *
      * @throws EntryDoesNotExistException
      *
      * @return mixed

--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -101,6 +101,8 @@ final class Configurator
      *
      * @param string $filename
      *
+     * @throws InvalidArgumentException
+     *
      * @return Configurator
      */
     public function configFromFile($filename)

--- a/src/FileReader/ReaderFactory.php
+++ b/src/FileReader/ReaderFactory.php
@@ -49,6 +49,8 @@ final class ReaderFactory
     /**
      * @param string $filename
      *
+     * @throws UnknownFileTypeException
+     *
      * @return string
      */
     private function getReaderClass($filename)

--- a/src/Pimple/PimpleContainerAdapter.php
+++ b/src/Pimple/PimpleContainerAdapter.php
@@ -48,6 +48,8 @@ final class PimpleContainerAdapter implements ContainerAdapter
     }
 
     /**
+     * @param InflectorConfig $config
+     *
      * @throws UnsupportedFeatureException
      */
     public function addInflectorConfig(InflectorConfig $config)


### PR DESCRIPTION
This PR

* [x] adds missing `@throws` and `@param` annotations to docblocks