### PR TITLE
Fix: Actually reset static property

### DIFF
--- a/tests/mocks/FileReader/CustomFileReader.php
+++ b/tests/mocks/FileReader/CustomFileReader.php
@@ -10,7 +10,7 @@ final class CustomFileReader implements FileReader
 
     public static function reset()
     {
-        $reads = [];
+        self::$reads = [];
     }
 
     public static function getReads()


### PR DESCRIPTION
This PR

* [x] actually resets a static field in a mock

Follows https://github.com/tomphp/container-configurator/pull/76.

💁‍♂️ It hasn't been an issue so far as we only use the `CustomFileReader` mock once in tests.