### PR TITLE
Fix: Require squizlabs/php_codesniffer using concrete version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "league/container": "^2.0.2",
         "phpunit/phpunit": "^5.5.4",
         "pimple/pimple": "^3.0.0",
-        "squizlabs/php_codesniffer": "*",
+        "squizlabs/php_codesniffer": "^2.8.0",
         "symfony/yaml": "^3.1.4"
     },
     "autoload": {


### PR DESCRIPTION
This PR

* [x] requires `squizlabs/php_codesniffer` using a concrete version requirement (rather than a wildcard)